### PR TITLE
Fix regex to allow urlencoded characters in slug

### DIFF
--- a/services/RTE/__init__.py
+++ b/services/RTE/__init__.py
@@ -97,7 +97,7 @@ class RTE(Service):
         title_re = (
             r"https://www\.rte\.ie/player"
             r"/(?P<type>series|movie)"
-            r"/(?P<slug>[a-zA-Z0-9_-]+)"
+            r"/(?P<slug>[a-zA-Z0-9%_-]+)"
             r"/(?P<id>[a-zA-Z0-9_\-=?]+)/?$"
         )
         try:


### PR DESCRIPTION
Trying to list episodes from https://www.rte.ie/player/series/la-vie-sa-bhruis%C3%A9il/10003899-00-0000 causes a crash with traceback of:

`ValueError: - Could not parse ID from input`

It will technically work if you replace the urlencoded "é" with an "e" in your target url as RTE does automatic redirect magic based on the series id 10003899-00-0000 but ideally the main series regex would support gaelic characters that have síneadh fadas which get urlencoded and thus we need to allow for % signs in the regex.